### PR TITLE
Allow setting extra ENV vars to calico-node

### DIFF
--- a/stable/aws-calico/Chart.yaml
+++ b/stable/aws-calico/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 description: A Helm chart for installing Calico on AWS
 website: https://docs.aws.amazon.com/eks/latest/userguide/calico.html
 name: aws-calico
-version: 0.2.2
+version: 0.2.3
 appVersion: 3.8.1
 icon: https://www.projectcalico.org/wp-content/uploads/2019/09/Calico_Logo_Large_Calico.png

--- a/stable/aws-calico/README.md
+++ b/stable/aws-calico/README.md
@@ -43,6 +43,7 @@ The following table lists the configurable parameters for this chart and their d
 | `calico.typha.image`    | Calico Typha Image                                      | `quay.io/calico/typha`          |
 | `calico.typha.resources`| Calico Typha Resources                                  | `requests.memory: 64Mi, requests.cpu: 50m, limits.memory: 96Mi, limits.cpu: 100m` |
 | `calico.typha.logseverity` | Calico Typha Log Severity                            | `Info`                          |
+| `calico.node.extraEnv`  | Calico Node extra ENV vars                              | `[]`                            |
 | `calico.node.image`     | Calico Node Image                                       | `quay.io/calico/node`           |
 | `calico.node.resources` | Calico Node Resources                                   | `requests.memory: 32Mi, requests.cpu: 20m, limits.memory: 64Mi, limits.cpu: 100m` |
 | `calico.node.logseverity` | Calico Node Log Severity                              | `Info`                          |

--- a/stable/aws-calico/templates/daemon-set.yaml
+++ b/stable/aws-calico/templates/daemon-set.yaml
@@ -82,6 +82,9 @@ spec:
               value: ""
             - name: FELIX_HEALTHENABLED
               value: "true"
+          {{- if .Values.calico.node.extraEnv }}
+            {{- toYaml .Values.calico.node.extraEnv | nindent 12 }}
+          {{- end }}
           securityContext:
             privileged: true
           livenessProbe:

--- a/stable/aws-calico/values.yaml
+++ b/stable/aws-calico/values.yaml
@@ -26,6 +26,9 @@ calico:
       limits:
         memory: "64Mi"
         cpu: "100m"
+    extraEnv: []
+    # - name: SOME_VAR
+    #   value: 'some value'
   typha_autoscaler:
     resources:
       requests:


### PR DESCRIPTION
Signed-off-by: Philip Dubois <hello@philipdubois.be>

Issue #, if available: https://github.com/skyscrapers/engineering/issues/369

Description of changes: Allow setting extra ENV vars to calico-node, for example `FELIX_CHAININSERTMODE`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
